### PR TITLE
Fix dset1 -> dset2 in HW1 TeX template.

### DIFF
--- a/homeworks/hw1/hw1_latex/main.tex
+++ b/homeworks/hw1/hw1_latex/main.tex
@@ -283,7 +283,7 @@ Final test loss for dataset 2: \textcolor{red}{FILL IN HERE}  nats / dim
 \item {\bf [15pt] K,V Caching for Improved Inference} \\\\
 \begin{figure}[H]
     \centering
-    \includegraphics[width=\textwidth]{figures/q3_c_dset1_timing_plot.png}
+    \includegraphics[width=\textwidth]{figures/q3_c_dset2_timing_plot.png}
     \caption{Dataset 2: Inference Speed}
 \end{figure}
 
@@ -291,13 +291,13 @@ Final test loss for dataset 2: \textcolor{red}{FILL IN HERE}  nats / dim
     \centering
     \begin{subfigure}{0.45\textwidth}
         \centering
-        \includegraphics[width=\textwidth]{figures/q3_c_no_cache_dset1_samples.png}
+        \includegraphics[width=\textwidth]{figures/q3_c_no_cache_dset2_samples.png}
         \caption{Dataset 2: Samples (no caching)}
     \end{subfigure}
     \hspace{0.2in}
     \begin{subfigure}{0.45\textwidth}
         \centering
-        \includegraphics[width=\textwidth]{figures/q3_c_with_cache_dset1_samples.png}
+        \includegraphics[width=\textwidth]{figures/q3_c_with_cache_dset2_samples.png}
         \caption{Dataset 2: Samples (caching)}
     \end{subfigure}
 \end{figure}


### PR DESCRIPTION
Fixing a minor nit, the figure paths in the TeX template for the K,V caching problem say `dset1` whereas the notebook only asks us to do it for `dset2` and the `hw1_helper` outputs filenames with `dset2`. This fixes the TeX to also be `dset2`.